### PR TITLE
fix alias block bug

### DIFF
--- a/alias/alias.go
+++ b/alias/alias.go
@@ -64,8 +64,11 @@ func (as *Aliases) Compile(aliases []*Alias) error {
 func (as *Aliases) Find(engine, name string) (*Alias, bool) {
 	if engineMap, ok := as.Map[engine]; ok {
 		if aliasName, ok := engineMap[name]; ok {
-			if alias, ok := as.Aliases[aliasName]; ok && !alias.blocked[engine] {
-				return alias, true
+			if alias, ok := as.Aliases[aliasName]; ok {
+				if !alias.blocked[engine] {
+					return alias, true
+				}
+				return alias, false
 			}
 		}
 	}
@@ -98,6 +101,10 @@ type Alias struct {
 	AliasMap       map[string][]string `json:"alias" yaml:"alias"`
 	Block          []string            `json:"block,omitempty" yaml:"block"`
 	blocked        map[string]bool
+}
+
+func (a *Alias) IsBlocked(key string) bool {
+	return a.blocked[key]
 }
 
 func (a *Alias) FuzzyMatch(s string) bool {

--- a/engine.go
+++ b/engine.go
@@ -292,9 +292,14 @@ func (engine *Engine) MatchFavicon(content []byte) common.Frameworks {
 func (engine *Engine) MergeFrameworks(origin, other common.Frameworks) common.Frameworks {
 	for _, frame := range other {
 		aliasFrame, ok := engine.Aliases.FindFramework(frame)
-		if ok {
-			frame.Name = aliasFrame.Name
-			frame.UpdateAttributes(aliasFrame.ToWFN())
+		if aliasFrame != nil {
+			if ok {
+				frame.Name = aliasFrame.Name
+				frame.UpdateAttributes(aliasFrame.ToWFN())
+			}
+			if aliasFrame.IsBlocked(frame.From.String()) {
+				continue
+			}
 		}
 		origin.Add(frame)
 	}

--- a/resources/aliases.yaml
+++ b/resources/aliases.yaml
@@ -392,5 +392,20 @@
     fingerprinthub:
       - 红帆 Ioffice
 
+- name: redis
+  vendor: Redis
+  product: Redis
+  alias:
+    goby:
+      - Redis
+  block:
+    - goby
 
-
+- name: ibm-db2 database
+  vendor: ibm
+  product: db2
+  alias:
+    goby:
+      - IBM-DB2 database
+  block:
+    - goby


### PR DESCRIPTION
1. 在aliases.yaml中添加block配置示例。
2. 修复block过滤失效问题：
  - 原因是MergeFrameworks添加所有frame到origin时，绕过了block过滤。

