### PR TITLE
fix some bug

### DIFF
--- a/goby/goby.go
+++ b/goby/goby.go
@@ -75,8 +75,10 @@ type GobyFinger struct {
 }
 
 func (finger *GobyFinger) Compile() error {
-	for _, r := range finger.Rule {
-		r.Feature = strings.ToLower(r.Feature)
+	for i, r := range finger.Rule {
+		// Fix bug: golang 不支持直接使用 `r.Feature` 的方式修改循环内的值
+		//r.Feature = strings.ToLower(r.Feature)
+		finger.Rule[i].Feature = strings.ToLower(r.Feature)
 	}
 
 	finger.logicExpr = logic.Compile(finger.Logic)

--- a/wappalyzer/fingerprints.go
+++ b/wappalyzer/fingerprints.go
@@ -22,7 +22,7 @@ type Fingerprint struct {
 	Headers     map[string]string   `json:"headers"`
 	HTML        []string            `json:"html"`
 	Script      []string            `json:"scripts"`
-	ScriptSrc   []string            `json:"scriptSrcs"`
+	ScriptSrc   []string            `json:"scriptSrc"`
 	Meta        map[string][]string `json:"meta"`
 	Implies     []string            `json:"implies"`
 	Description string              `json:"description"`
@@ -99,6 +99,7 @@ const versionPrefix = "version:\\"
 // newVersionRegex creates a new version matching regex
 // TODO: handles simple group cases only as of now (no ternary)
 func newVersionRegex(value string) (*versionRegex, error) {
+	value = strings.ToLower(value)
 	splitted := strings.Split(value, "\\;")
 	if len(splitted) == 0 {
 		return nil, nil


### PR DESCRIPTION
修复了一些指纹匹配的BUG：
1. ehole 中正则和关键字匹配使用 append 追加数组会导致出现多个 nil 或者空字符串的问题；
2. 指纹引擎会将待检测的内容全部转小写，所以 ehole 关键字匹配应该使用 LowerKeyword 检测；
3. goby 引擎的 finger.Rule 不是指针，循环内赋值会导致失效；
4. wappalyzer 的指纹库字段是 scriptSrc；