### PR TITLE
fix: HTTPActiveMatch callback 返回错误的 framework 及模板编译选项丢失

### DIFF
--- a/fingerprinthub/fingerprinthub.go
+++ b/fingerprinthub/fingerprinthub.go
@@ -88,11 +88,17 @@ type FingerPrintHubEngine struct {
 	serviceTemplates []*templates.Template // Service 指纹模板
 	executerOptions  *protocols.ExecuterOptions
 	webTemplateIndex *TemplateKeywordIndex // AC keyword index for web template prefiltering
+
+	// CaseInsensitive 控制匹配时是否忽略大小写（默认 true）。
+	// 开启时 event 中的 body/header 统一 ToLower，word matcher keywords 也在编译时 ToLower。
+	// DSL/Regex 模板中的字面量需使用小写以配合此模式。
+	CaseInsensitive bool
 }
 
 // NewFingerPrintHubEngine 创建新的引擎实例
 func NewFingerPrintHubEngine(webData, serviceData []byte) (*FingerPrintHubEngine, error) {
 	engine := &FingerPrintHubEngine{
+		CaseInsensitive:  true,
 		webTemplates:     make([]*templates.Template, 0),
 		serviceTemplates: make([]*templates.Template, 0),
 		executerOptions: &protocols.ExecuterOptions{
@@ -155,17 +161,7 @@ func (engine *FingerPrintHubEngine) loadTemplates(templateData []map[string]inte
 			continue
 		}
 
-		// 强制所有 word matcher 为 case-insensitive，
-		// 使 word matcher 内部自行处理大小写，不依赖外部对 body/header 做 ToLower
-		for _, req := range tmpl.GetRequests() {
-			for _, matcher := range req.Matchers {
-				if matcher.Type == "word" {
-					matcher.CaseInsensitive = true
-				}
-			}
-		}
-
-		if err := tmpl.Compile(engine.executerOptions); err != nil {
+		if err := engine.compileTemplate(tmpl); err != nil {
 			errors = append(errors, fmt.Errorf("failed to compile template %s: %w", tmpl.Id, err))
 			continue
 		}
@@ -192,6 +188,22 @@ func (engine *FingerPrintHubEngine) loadTemplates(templateData []map[string]inte
 	}
 
 	return loadedCount, errors
+}
+
+// compileTemplate 编译模板。当 CaseInsensitive 开启时，设置 word matcher
+// 的 CaseInsensitive 标志，使 neutron 在编译时将 keywords ToLower，
+// 匹配时将 corpus ToLower。所有模板加载路径都必须经过此方法。
+func (engine *FingerPrintHubEngine) compileTemplate(tmpl *templates.Template) error {
+	if engine.CaseInsensitive {
+		for _, req := range tmpl.GetRequests() {
+			for _, matcher := range req.Matchers {
+				if matcher.Type == "word" {
+					matcher.CaseInsensitive = true
+				}
+			}
+		}
+	}
+	return tmpl.Compile(engine.executerOptions)
 }
 
 // LoadFromJSON 从 JSON 数据加载指纹
@@ -224,8 +236,7 @@ func (engine *FingerPrintHubEngine) LoadFromJSON(data []byte) error {
 			continue
 		}
 
-		err = tmpl.Compile(engine.executerOptions)
-		if err != nil {
+		if err = engine.compileTemplate(tmpl); err != nil {
 			errors = append(errors, fmt.Errorf("failed to compile template %s: %w", tmpl.Id, err))
 			continue
 		}
@@ -384,19 +395,27 @@ func (engine *FingerPrintHubEngine) WebMatch(content []byte) common.Frameworks {
 		return make(common.Frameworks)
 	}
 
-	// 读取原始 body，保留大小写给 DSL/regex matcher
 	rawBody := httputils.ReadBody(resp)
-	rawBodyStr := string(rawBody)
+	bodyStr := string(rawBody)
 
-	// 构建 neutron 格式的 InternalEvent（使用原始大小写）
-	event := engine.buildInternalEvent(resp, rawBodyStr, len(content))
+	// AC index 始终使用小写进行关键词预过滤
+	lowerBodyStr := strings.ToLower(bodyStr)
+
+	// CaseInsensitive 开启时，event 中的 body/header 使用小写，
+	// 使 word/DSL/regex 等所有 matcher 统一在小写上匹配
+	if engine.CaseInsensitive {
+		bodyStr = lowerBodyStr
+	}
+
+	event := engine.buildInternalEvent(resp, bodyStr, len(content))
 
 	frames := make(common.Frameworks)
 
-	// AC index 使用小写版本做关键词预过滤
-	lowerBodyStr := strings.ToLower(rawBodyStr)
 	headerStr, _ := event["all_headers"].(string)
-	lowerHeaderStr := strings.ToLower(headerStr)
+	lowerHeaderStr := headerStr
+	if !engine.CaseInsensitive {
+		lowerHeaderStr = strings.ToLower(headerStr)
+	}
 	mr := engine.webTemplateIndex.Match(lowerHeaderStr, lowerBodyStr)
 
 	// Fast path: AC keyword hit directly resolves these templates.
@@ -471,15 +490,19 @@ func (engine *FingerPrintHubEngine) buildInternalEvent(resp *http.Response, body
 	return event
 }
 
-// buildHeaderString 构建 header 字符串
-// key 统一小写（HTTP 规范 key 是 case-insensitive），value 保留原始大小写
+// buildHeaderString 构建 header 字符串。
+// key 始终小写（HTTP 规范）；value 根据 CaseInsensitive 开关决定。
 func (engine *FingerPrintHubEngine) buildHeaderString(header http.Header) string {
 	var builder strings.Builder
 	for key, values := range header {
 		for _, value := range values {
 			builder.WriteString(strings.ToLower(key))
 			builder.WriteString(": ")
-			builder.WriteString(value)
+			if engine.CaseInsensitive {
+				builder.WriteString(strings.ToLower(value))
+			} else {
+				builder.WriteString(value)
+			}
 			builder.WriteString("\n")
 		}
 	}

--- a/fingerprinthub/fingerprinthub.go
+++ b/fingerprinthub/fingerprinthub.go
@@ -420,11 +420,20 @@ func (engine *FingerPrintHubEngine) WebMatch(content []byte) common.Frameworks {
 
 	// Fast path: AC keyword hit directly resolves these templates.
 	// All matchers are Word type with OR condition — AC match = matched.
-	for ti := range mr.Matched {
-		frames.Add(engine.newFramework(engine.webTemplates[ti]))
+	// 仅在 CaseInsensitive 模式下可用，因为 AC index 始终用小写匹配。
+	if engine.CaseInsensitive {
+		for ti := range mr.Matched {
+			frames.Add(engine.newFramework(engine.webTemplates[ti]))
+		}
 	}
 
 	// Slow path: templates needing full matchRequest (regex, AND, fallback).
+	// CaseSensitive 模式下 AC fast path 的结果也走 slow path 以确保精确匹配。
+	if !engine.CaseInsensitive {
+		for ti := range mr.Matched {
+			mr.NeedsCheck[ti] = true
+		}
+	}
 	for ti := range mr.NeedsCheck {
 		tmpl := engine.webTemplates[ti]
 		requests := tmpl.GetRequests()

--- a/fingerprinthub/fingerprinthub.go
+++ b/fingerprinthub/fingerprinthub.go
@@ -165,8 +165,7 @@ func (engine *FingerPrintHubEngine) loadTemplates(templateData []map[string]inte
 			}
 		}
 
-		opts := &protocols.ExecuterOptions{Options: engine.executerOptions.Options}
-		if err := tmpl.Compile(opts); err != nil {
+		if err := tmpl.Compile(engine.executerOptions); err != nil {
 			errors = append(errors, fmt.Errorf("failed to compile template %s: %w", tmpl.Id, err))
 			continue
 		}
@@ -225,8 +224,7 @@ func (engine *FingerPrintHubEngine) LoadFromJSON(data []byte) error {
 			continue
 		}
 
-		loadOpts := &protocols.ExecuterOptions{Options: engine.executerOptions.Options}
-		err = tmpl.Compile(loadOpts)
+		err = tmpl.Compile(engine.executerOptions)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("failed to compile template %s: %w", tmpl.Id, err))
 			continue
@@ -404,7 +402,7 @@ func (engine *FingerPrintHubEngine) WebMatch(content []byte) common.Frameworks {
 	// Fast path: AC keyword hit directly resolves these templates.
 	// All matchers are Word type with OR condition — AC match = matched.
 	for ti := range mr.Matched {
-		engine.addFramework(frames, engine.webTemplates[ti])
+		frames.Add(engine.newFramework(engine.webTemplates[ti]))
 	}
 
 	// Slow path: templates needing full matchRequest (regex, AND, fallback).
@@ -421,7 +419,7 @@ func (engine *FingerPrintHubEngine) WebMatch(content []byte) common.Frameworks {
 			}
 
 			if engine.matchRequest(req, event) {
-				engine.addFramework(frames, tmpl)
+				frames.Add(engine.newFramework(tmpl))
 				break
 			}
 		}
@@ -430,7 +428,7 @@ func (engine *FingerPrintHubEngine) WebMatch(content []byte) common.Frameworks {
 	return frames
 }
 
-func (engine *FingerPrintHubEngine) addFramework(frames common.Frameworks, tmpl *templates.Template) {
+func (engine *FingerPrintHubEngine) newFramework(tmpl *templates.Template) *common.Framework {
 	name := tmpl.Info.Name
 	if name == "" {
 		name = tmpl.Id
@@ -444,7 +442,7 @@ func (engine *FingerPrintHubEngine) addFramework(frames common.Frameworks, tmpl 
 			frame.Attributes.Product = product
 		}
 	}
-	frames.Add(frame)
+	return frame
 }
 
 // buildInternalEvent 构建 neutron 的 InternalEvent
@@ -566,9 +564,10 @@ func (engine *FingerPrintHubEngine) HTTPActiveMatch(baseURL string, level int, t
 
 			err := httpReq.ExecuteWithResults(scanCtx, make(map[string]interface{}), make(map[string]interface{}), func(event *protocols.InternalWrappedEvent) {
 				if event.OperatorsResult != nil && event.OperatorsResult.Matched {
-					engine.addFramework(allFrameworks, tmpl)
+					frame := engine.newFramework(tmpl)
+					allFrameworks.Add(frame)
 					if callback != nil {
-						callback(allFrameworks.One(), nil)
+						callback(frame, nil)
 					}
 				}
 			})

--- a/fingerprinthub/fingerprinthub_test.go
+++ b/fingerprinthub/fingerprinthub_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/chainreactors/fingers/resources"
 	"github.com/chainreactors/neutron/operators"
+	"github.com/chainreactors/neutron/protocols"
+	"github.com/chainreactors/neutron/templates"
 	"github.com/chainreactors/utils/encode"
 )
 
@@ -56,6 +58,56 @@ func TestFingerPrintHubEngine_WebMatch(t *testing.T) {
 	}
 
 	t.Logf("✅ Empty engine correctly returns no matches")
+}
+
+// ============================================================================
+// DSL case-sensitivity regression test
+// ============================================================================
+
+func TestWebMatch_DSLCaseSensitivity(t *testing.T) {
+	engine := &FingerPrintHubEngine{
+		webTemplates:    make([]*templates.Template, 0),
+		executerOptions: &protocols.ExecuterOptions{Options: &protocols.Options{Timeout: 10}},
+	}
+
+	tmplData := []map[string]interface{}{
+		{
+			"id": "test-dsl-case",
+			"info": map[string]interface{}{
+				"name":     "Test DSL Case",
+				"severity": "info",
+			},
+			"http": []interface{}{
+				map[string]interface{}{
+					"method":             "GET",
+					"path":               []interface{}{"{{BaseURL}}/"},
+					"matchers-condition": "and",
+					"matchers": []interface{}{
+						map[string]interface{}{
+							"type": "dsl",
+							"dsl":  []interface{}{`contains(body, "<title>Nacos") && contains(body, "console-ui/public/js/xml.js")`},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	count, errs := engine.loadTemplates(tmplData, true)
+	if count == 0 {
+		t.Fatalf("loadTemplates returned 0; errors: %v", errs)
+	}
+	engine.webTemplateIndex = NewTemplateKeywordIndex(engine.webTemplates)
+
+	raw := "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n" +
+		"<html><head><title>Nacos</title></head><body>" +
+		"<script src=\"console-ui/public/js/xml.js\"></script></body></html>"
+
+	frames := engine.WebMatch([]byte(raw))
+	if len(frames) == 0 {
+		t.Fatal("expected DSL matcher to match mixed-case body, got 0 results")
+	}
+	t.Logf("matched: %v", frameworkNames(frames))
 }
 
 // ============================================================================

--- a/fingerprinthub/fingerprinthub_test.go
+++ b/fingerprinthub/fingerprinthub_test.go
@@ -61,31 +61,48 @@ func TestFingerPrintHubEngine_WebMatch(t *testing.T) {
 }
 
 // ============================================================================
-// DSL case-sensitivity regression test
+// CaseInsensitive 开关测试
 // ============================================================================
 
-func TestWebMatch_DSLCaseSensitivity(t *testing.T) {
-	engine := &FingerPrintHubEngine{
+func newTestEngine(caseInsensitive bool) *FingerPrintHubEngine {
+	return &FingerPrintHubEngine{
+		CaseInsensitive: caseInsensitive,
 		webTemplates:    make([]*templates.Template, 0),
 		executerOptions: &protocols.ExecuterOptions{Options: &protocols.Options{Timeout: 10}},
 	}
+}
+
+// CaseInsensitive=true（默认）: body 已 ToLower，DSL 字面量用小写
+func TestWebMatch_CaseInsensitive(t *testing.T) {
+	engine := newTestEngine(true)
 
 	tmplData := []map[string]interface{}{
 		{
-			"id": "test-dsl-case",
-			"info": map[string]interface{}{
-				"name":     "Test DSL Case",
-				"severity": "info",
-			},
+			"id": "test-ci-dsl",
+			"info": map[string]interface{}{"name": "Test CI DSL", "severity": "info"},
 			"http": []interface{}{
 				map[string]interface{}{
-					"method":             "GET",
-					"path":               []interface{}{"{{BaseURL}}/"},
+					"method": "GET", "path": []interface{}{"{{BaseURL}}/"},
 					"matchers-condition": "and",
 					"matchers": []interface{}{
 						map[string]interface{}{
 							"type": "dsl",
-							"dsl":  []interface{}{`contains(body, "<title>Nacos") && contains(body, "console-ui/public/js/xml.js")`},
+							"dsl":  []interface{}{`contains(body, "<title>nacos")`},
+						},
+					},
+				},
+			},
+		},
+		{
+			"id": "test-ci-word",
+			"info": map[string]interface{}{"name": "Test CI Word", "severity": "info"},
+			"http": []interface{}{
+				map[string]interface{}{
+					"method": "GET", "path": []interface{}{"{{BaseURL}}/"},
+					"matchers": []interface{}{
+						map[string]interface{}{
+							"type":  "word",
+							"words": []interface{}{"<title>Nacos"},
 						},
 					},
 				},
@@ -94,20 +111,76 @@ func TestWebMatch_DSLCaseSensitivity(t *testing.T) {
 	}
 
 	count, errs := engine.loadTemplates(tmplData, true)
-	if count == 0 {
-		t.Fatalf("loadTemplates returned 0; errors: %v", errs)
+	if count != 2 {
+		t.Fatalf("loadTemplates: loaded=%d, errors: %v", count, errs)
 	}
 	engine.webTemplateIndex = NewTemplateKeywordIndex(engine.webTemplates)
 
 	raw := "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n" +
-		"<html><head><title>Nacos</title></head><body>" +
-		"<script src=\"console-ui/public/js/xml.js\"></script></body></html>"
+		"<html><head><title>Nacos</title></head></html>"
 
 	frames := engine.WebMatch([]byte(raw))
-	if len(frames) == 0 {
-		t.Fatal("expected DSL matcher to match mixed-case body, got 0 results")
+	if len(frames) != 2 {
+		t.Fatalf("CaseInsensitive=true: expected 2 matches, got %d: %v", len(frames), frameworkNames(frames))
 	}
-	t.Logf("matched: %v", frameworkNames(frames))
+	t.Logf("CaseInsensitive=true matched: %v", frameworkNames(frames))
+}
+
+// CaseInsensitive=false: body 保留原始大小写，DSL 字面量可用混合大小写
+func TestWebMatch_CaseSensitive(t *testing.T) {
+	engine := newTestEngine(false)
+
+	tmplData := []map[string]interface{}{
+		{
+			"id": "test-cs-dsl-match",
+			"info": map[string]interface{}{"name": "CS DSL Match", "severity": "info"},
+			"http": []interface{}{
+				map[string]interface{}{
+					"method": "GET", "path": []interface{}{"{{BaseURL}}/"},
+					"matchers": []interface{}{
+						map[string]interface{}{
+							"type": "dsl",
+							"dsl":  []interface{}{`contains(body, "<title>Nacos")`},
+						},
+					},
+				},
+			},
+		},
+		{
+			"id": "test-cs-dsl-nomatch",
+			"info": map[string]interface{}{"name": "CS DSL NoMatch", "severity": "info"},
+			"http": []interface{}{
+				map[string]interface{}{
+					"method": "GET", "path": []interface{}{"{{BaseURL}}/"},
+					"matchers": []interface{}{
+						map[string]interface{}{
+							"type": "dsl",
+							"dsl":  []interface{}{`contains(body, "<title>NACOS")`},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	count, errs := engine.loadTemplates(tmplData, true)
+	if count != 2 {
+		t.Fatalf("loadTemplates: loaded=%d, errors: %v", count, errs)
+	}
+	engine.webTemplateIndex = NewTemplateKeywordIndex(engine.webTemplates)
+
+	raw := "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n" +
+		"<html><head><title>Nacos</title></head></html>"
+
+	frames := engine.WebMatch([]byte(raw))
+	names := frameworkNames(frames)
+	if len(frames) != 1 {
+		t.Fatalf("CaseSensitive: expected 1 match, got %d: %v", len(frames), names)
+	}
+	if _, ok := frames["cs dsl match"]; !ok {
+		t.Fatalf("CaseSensitive: expected 'cs dsl match', got %v", names)
+	}
+	t.Logf("CaseSensitive matched: %v", names)
 }
 
 // ============================================================================

--- a/fingerprinthub/fingerprinthub_test.go
+++ b/fingerprinthub/fingerprinthub_test.go
@@ -62,6 +62,12 @@ func TestFingerPrintHubEngine_WebMatch(t *testing.T) {
 
 // ============================================================================
 // CaseInsensitive 开关测试
+//
+// 模拟真实指纹场景，覆盖所有 matcher 类型 × match part × 两种模式。
+//
+// 测试用的 HTTP 响应模拟一个典型的 Nacos 控制台页面：
+//   - Server: Tengine/2.3.3 (header 混合大小写)
+//   - body 包含 <title>Nacos</title>、版本号、JS 路径等混合大小写内容
 // ============================================================================
 
 func newTestEngine(caseInsensitive bool) *FingerPrintHubEngine {
@@ -72,115 +78,271 @@ func newTestEngine(caseInsensitive bool) *FingerPrintHubEngine {
 	}
 }
 
-// CaseInsensitive=true（默认）: body 已 ToLower，DSL 字面量用小写
-func TestWebMatch_CaseInsensitive(t *testing.T) {
-	engine := newTestEngine(true)
+const testHTTPRaw = "HTTP/1.1 200 OK\r\n" +
+	"Server: Tengine/2.3.3\r\n" +
+	"Content-Type: text/html; charset=UTF-8\r\n" +
+	"X-Powered-By: Nacos-Server/2.1.0\r\n" +
+	"\r\n" +
+	`<html><head><title>Nacos</title></head><body>` +
+	`<div id="root"><script src="console-ui/public/js/vs/loader/loader.js"></script>` +
+	`<p>Welcome to Nacos v2.1.0</p></body></html>`
 
-	tmplData := []map[string]interface{}{
-		{
-			"id": "test-ci-dsl",
-			"info": map[string]interface{}{"name": "Test CI DSL", "severity": "info"},
-			"http": []interface{}{
-				map[string]interface{}{
-					"method": "GET", "path": []interface{}{"{{BaseURL}}/"},
-					"matchers-condition": "and",
-					"matchers": []interface{}{
-						map[string]interface{}{
-							"type": "dsl",
-							"dsl":  []interface{}{`contains(body, "<title>nacos")`},
-						},
-					},
-				},
+func buildTestTemplates() []map[string]interface{} {
+	info := func(name string) map[string]interface{} {
+		return map[string]interface{}{"name": name, "severity": "info"}
+	}
+	httpReq := func(matchers []interface{}) []interface{} {
+		return []interface{}{
+			map[string]interface{}{
+				"method": "GET", "path": []interface{}{"{{BaseURL}}/"},
+				"matchers": matchers,
 			},
+		}
+	}
+	httpReqAnd := func(matchers []interface{}) []interface{} {
+		return []interface{}{
+			map[string]interface{}{
+				"method": "GET", "path": []interface{}{"{{BaseURL}}/"},
+				"matchers-condition": "and",
+				"matchers":           matchers,
+			},
+		}
+	}
+
+	return []map[string]interface{}{
+		// ── Word matcher: body ──
+		// keywords 用混合大小写，CaseInsensitive 模式下 neutron 会 ToLower 双方
+		{
+			"id": "word-body-mixed", "info": info("Word Body Mixed"),
+			"http": httpReq([]interface{}{
+				map[string]interface{}{"type": "word", "words": []interface{}{"<title>Nacos</title>"}},
+			}),
+		},
+		// keywords 用小写，两种模式都应该匹配
+		{
+			"id": "word-body-lower", "info": info("Word Body Lower"),
+			"http": httpReq([]interface{}{
+				map[string]interface{}{"type": "word", "words": []interface{}{"<title>nacos</title>"}},
+			}),
+		},
+		// keywords 用全大写，只有 CaseInsensitive 模式匹配
+		{
+			"id": "word-body-upper", "info": info("Word Body Upper"),
+			"http": httpReq([]interface{}{
+				map[string]interface{}{"type": "word", "words": []interface{}{"<TITLE>NACOS</TITLE>"}},
+			}),
+		},
+
+		// ── Word matcher: header ──
+		// 检查 Server header（原始 "Tengine/2.3.3"）
+		{
+			"id": "word-header-mixed", "info": info("Word Header Mixed"),
+			"http": httpReq([]interface{}{
+				map[string]interface{}{"type": "word", "part": "header", "words": []interface{}{"Tengine/2.3.3"}},
+			}),
 		},
 		{
-			"id": "test-ci-word",
-			"info": map[string]interface{}{"name": "Test CI Word", "severity": "info"},
-			"http": []interface{}{
+			"id": "word-header-lower", "info": info("Word Header Lower"),
+			"http": httpReq([]interface{}{
+				map[string]interface{}{"type": "word", "part": "header", "words": []interface{}{"tengine/2.3.3"}},
+			}),
+		},
+
+		// ── Word matcher: AND 条件（多关键词同时命中）──
+		{
+			"id": "word-and-body", "info": info("Word AND Body"),
+			"http": httpReqAnd([]interface{}{
+				map[string]interface{}{"type": "word", "words": []interface{}{"nacos"}},
+				map[string]interface{}{"type": "word", "part": "header", "words": []interface{}{"tengine"}},
+			}),
+		},
+
+		// ── Regex matcher: body ──
+		// 提取版本号 — 小写 pattern
+		{
+			"id": "regex-body-version", "info": info("Regex Body Version"),
+			"http": httpReq([]interface{}{
+				map[string]interface{}{"type": "regex", "regex": []interface{}{`nacos v[\d.]+`}},
+			}),
+		},
+		// 混合大小写 pattern — 仅 CaseSensitive 模式匹配
+		{
+			"id": "regex-body-mixed", "info": info("Regex Body Mixed"),
+			"http": httpReq([]interface{}{
+				map[string]interface{}{"type": "regex", "regex": []interface{}{`Nacos v[\d.]+`}},
+			}),
+		},
+
+		// ── Regex matcher: header ──
+		// 从 header 提取 Tengine 版本
+		{
+			"id": "regex-header-version", "info": info("Regex Header Version"),
+			"http": httpReq([]interface{}{
+				map[string]interface{}{"type": "regex", "part": "header", "regex": []interface{}{`tengine/[\d.]+`}},
+			}),
+		},
+
+		// ── DSL matcher: body ──
+		// 使用 contains + status_code 组合
+		{
+			"id": "dsl-body-lower", "info": info("DSL Body Lower"),
+			"http": httpReq([]interface{}{
 				map[string]interface{}{
-					"method": "GET", "path": []interface{}{"{{BaseURL}}/"},
-					"matchers": []interface{}{
-						map[string]interface{}{
-							"type":  "word",
-							"words": []interface{}{"<title>Nacos"},
-						},
-					},
+					"type": "dsl",
+					"dsl":  []interface{}{`status_code == 200 && contains(body, "<title>nacos</title>")`},
 				},
-			},
+			}),
+		},
+		// 混合大小写字面量 — 仅 CaseSensitive 模式匹配
+		{
+			"id": "dsl-body-mixed", "info": info("DSL Body Mixed"),
+			"http": httpReq([]interface{}{
+				map[string]interface{}{
+					"type": "dsl",
+					"dsl":  []interface{}{`contains(body, "<title>Nacos</title>")`},
+				},
+			}),
+		},
+
+		// ── DSL matcher: header ──
+		// 检查 X-Powered-By header（通过 all_headers）
+		{
+			"id": "dsl-header", "info": info("DSL Header"),
+			"http": httpReq([]interface{}{
+				map[string]interface{}{
+					"type": "dsl",
+					"dsl":  []interface{}{`contains(all_headers, "nacos-server")`},
+				},
+			}),
+		},
+
+		// ── Status matcher（不受大小写影响）──
+		{
+			"id": "status-200", "info": info("Status 200"),
+			"http": httpReq([]interface{}{
+				map[string]interface{}{"type": "status", "status": []interface{}{200}},
+			}),
+		},
+
+		// ── AND 组合：word(header) + regex(body) + status ──
+		{
+			"id": "combo-and", "info": info("Combo AND"),
+			"http": httpReqAnd([]interface{}{
+				map[string]interface{}{"type": "status", "status": []interface{}{200}},
+				map[string]interface{}{"type": "word", "part": "header", "words": []interface{}{"Tengine"}},
+				map[string]interface{}{"type": "regex", "regex": []interface{}{`console-ui/public/js`}},
+			}),
 		},
 	}
-
-	count, errs := engine.loadTemplates(tmplData, true)
-	if count != 2 {
-		t.Fatalf("loadTemplates: loaded=%d, errors: %v", count, errs)
-	}
-	engine.webTemplateIndex = NewTemplateKeywordIndex(engine.webTemplates)
-
-	raw := "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n" +
-		"<html><head><title>Nacos</title></head></html>"
-
-	frames := engine.WebMatch([]byte(raw))
-	if len(frames) != 2 {
-		t.Fatalf("CaseInsensitive=true: expected 2 matches, got %d: %v", len(frames), frameworkNames(frames))
-	}
-	t.Logf("CaseInsensitive=true matched: %v", frameworkNames(frames))
 }
 
-// CaseInsensitive=false: body 保留原始大小写，DSL 字面量可用混合大小写
-func TestWebMatch_CaseSensitive(t *testing.T) {
-	engine := newTestEngine(false)
+func TestCaseInsensitive_AllMatchers(t *testing.T) {
+	engine := newTestEngine(true)
 
-	tmplData := []map[string]interface{}{
-		{
-			"id": "test-cs-dsl-match",
-			"info": map[string]interface{}{"name": "CS DSL Match", "severity": "info"},
-			"http": []interface{}{
-				map[string]interface{}{
-					"method": "GET", "path": []interface{}{"{{BaseURL}}/"},
-					"matchers": []interface{}{
-						map[string]interface{}{
-							"type": "dsl",
-							"dsl":  []interface{}{`contains(body, "<title>Nacos")`},
-						},
-					},
-				},
-			},
-		},
-		{
-			"id": "test-cs-dsl-nomatch",
-			"info": map[string]interface{}{"name": "CS DSL NoMatch", "severity": "info"},
-			"http": []interface{}{
-				map[string]interface{}{
-					"method": "GET", "path": []interface{}{"{{BaseURL}}/"},
-					"matchers": []interface{}{
-						map[string]interface{}{
-							"type": "dsl",
-							"dsl":  []interface{}{`contains(body, "<title>NACOS")`},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	count, errs := engine.loadTemplates(tmplData, true)
-	if count != 2 {
-		t.Fatalf("loadTemplates: loaded=%d, errors: %v", count, errs)
+	tmpls := buildTestTemplates()
+	count, errs := engine.loadTemplates(tmpls, true)
+	if count != len(tmpls) {
+		t.Fatalf("loaded %d/%d, errors: %v", count, len(tmpls), errs)
 	}
 	engine.webTemplateIndex = NewTemplateKeywordIndex(engine.webTemplates)
 
-	raw := "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n" +
-		"<html><head><title>Nacos</title></head></html>"
+	frames := engine.WebMatch([]byte(testHTTPRaw))
+	matched := frameworkNames(frames)
 
-	frames := engine.WebMatch([]byte(raw))
-	names := frameworkNames(frames)
-	if len(frames) != 1 {
-		t.Fatalf("CaseSensitive: expected 1 match, got %d: %v", len(frames), names)
+	// CaseInsensitive=true 时，所有字面量/keywords/patterns 只要大小写无关就能匹配
+	expect := map[string]bool{
+		"word body mixed":    true,
+		"word body lower":    true,
+		"word body upper":    true,
+		"word header mixed":  true,
+		"word header lower":  true,
+		"word and body":      true,
+		"regex body version": true,
+		"regex body mixed":   false, // regex 引擎不受 CaseInsensitive 控制，pattern "Nacos" 匹配不到小写 body
+		"regex header version": true,
+		"dsl body lower":     true,
+		"dsl body mixed":     false, // body 已 ToLower，"<title>Nacos" 匹配不到
+		"dsl header":         true,
+		"status 200":         true,
+		"combo and":          true,
 	}
-	if _, ok := frames["cs dsl match"]; !ok {
-		t.Fatalf("CaseSensitive: expected 'cs dsl match', got %v", names)
+
+	for name, shouldMatch := range expect {
+		_, got := frames[name]
+		if got != shouldMatch {
+			t.Errorf("CaseInsensitive=true: %q expected=%v got=%v", name, shouldMatch, got)
+		}
 	}
-	t.Logf("CaseSensitive matched: %v", names)
+	t.Logf("CaseInsensitive=true: %d matched: %v", len(matched), matched)
+}
+
+func TestCaseSensitive_AllMatchers(t *testing.T) {
+	engine := newTestEngine(false)
+
+	tmpls := buildTestTemplates()
+	count, errs := engine.loadTemplates(tmpls, true)
+	if count != len(tmpls) {
+		t.Fatalf("loaded %d/%d, errors: %v", count, len(tmpls), errs)
+	}
+	engine.webTemplateIndex = NewTemplateKeywordIndex(engine.webTemplates)
+
+	frames := engine.WebMatch([]byte(testHTTPRaw))
+	matched := frameworkNames(frames)
+
+	// CaseSensitive 时 body/header 保留原始大小写
+	// body: "<title>Nacos</title>...Nacos v2.1.0"
+	// header value: "Tengine/2.3.3", "Nacos-Server/2.1.0"
+	expect := map[string]bool{
+		"word body mixed":   true, // "Nacos" 在原始 body 中存在（case-sensitive word 无 ToLower）
+		"word body lower":   false, // "<title>nacos" 不在原始 body 中
+		"word body upper":   false, // "<TITLE>NACOS" 不在原始 body 中
+		"word header mixed": true,  // "Tengine/2.3.3" 在 header value 中
+		"word header lower": false, // "tengine/2.3.3" — header key 始终小写，但 value 保留原始 "Tengine/2.3.3"
+		"word and body":     false, // "nacos" 不在原始 body (小写 n)；即使 header 匹配，AND 也失败
+		"regex body version": false, // "nacos v[\d.]+" — body 中是 "Nacos v2.1.0"，小写 n 匹配不到
+		"regex body mixed":   true,  // "Nacos v[\d.]+" 精确匹配原始大小写
+		"regex header version": false, // "tengine/[\d.]+" — header value 是 "Tengine/2.3.3"
+		"dsl body lower":     false, // contains(body, "<title>nacos</title>") — body 中是 Nacos
+		"dsl body mixed":     true,  // contains(body, "<title>Nacos</title>") 精确匹配
+		"dsl header":         false, // contains(all_headers, "nacos-server") — header value 保留了 "Nacos-Server"
+		"status 200":         true,  // 不受大小写影响
+		"combo and":          true,  // status=200 ✓, "Tengine" 在 header ✓, "console-ui" 在 body ✓
+	}
+
+	for name, shouldMatch := range expect {
+		_, got := frames[name]
+		if got != shouldMatch {
+			t.Errorf("CaseSensitive: %q expected=%v got=%v", name, shouldMatch, got)
+		}
+	}
+	t.Logf("CaseSensitive: %d matched: %v", len(matched), matched)
+}
+
+// TestCaseInsensitive_LoadFromJSON 验证 LoadFromJSON 路径也正确应用 CaseInsensitive。
+// 这是之前 LoadFromJSON 漏设 CaseInsensitive 的回归测试。
+func TestCaseInsensitive_LoadFromJSON(t *testing.T) {
+	engine := newTestEngine(true)
+
+	jsonData := []byte(`[{
+		"id": "json-word-mixed",
+		"info": {"name": "JSON Word Mixed", "severity": "info"},
+		"http": [{
+			"method": "GET",
+			"path": ["{{BaseURL}}/"],
+			"matchers": [{"type": "word", "words": ["<title>Nacos"]}]
+		}]
+	}]`)
+
+	if err := engine.LoadFromJSON(jsonData); err != nil {
+		t.Fatalf("LoadFromJSON: %v", err)
+	}
+	engine.webTemplateIndex = NewTemplateKeywordIndex(engine.webTemplates)
+
+	frames := engine.WebMatch([]byte(testHTTPRaw))
+	if _, ok := frames["json word mixed"]; !ok {
+		t.Fatal("LoadFromJSON: word matcher with mixed-case keywords should match in CaseInsensitive mode")
+	}
+	t.Logf("LoadFromJSON CaseInsensitive=true: matched %v", frameworkNames(frames))
 }
 
 // ============================================================================

--- a/xray/dsl_test.go
+++ b/xray/dsl_test.go
@@ -23,7 +23,7 @@ func TestNginxDSLMatch(t *testing.T) {
 	}
 
 	// Check what buildEvent produces
-	event := buildEvent(resp, "<html><head><title>Welcome to CentOS</title></head><body>test</body></html>", len(raw))
+	event := engine.buildEvent(resp, "<html><head><title>Welcome to CentOS</title></head><body>test</body></html>", len(raw))
 
 	t.Logf("event keys:")
 	for k, v := range event {

--- a/xray/xray.go
+++ b/xray/xray.go
@@ -84,8 +84,7 @@ func (e *XrayEngine) loadTemplates(data []map[string]interface{}) (int, []error)
 			errs = append(errs, fmt.Errorf("unmarshal: %w", err))
 			continue
 		}
-		opts := &protocols.ExecuterOptions{Options: e.executerOptions.Options}
-		if err := tmpl.Compile(opts); err != nil {
+		if err := tmpl.Compile(e.executerOptions); err != nil {
 			for _, req := range tmpl.GetRequests() {
 				if compileErr := (&req.Operators).Compile(); compileErr != nil {
 					continue
@@ -126,7 +125,7 @@ func (e *XrayEngine) WebMatch(content []byte) common.Frameworks {
 
 	for _, tmpl := range e.templates {
 		if e.matchTemplatePassive(tmpl, event) {
-			e.addFramework(frames, tmpl)
+			frames.Add(e.newFramework(tmpl))
 		}
 	}
 	return frames
@@ -205,7 +204,7 @@ func buildEvent(resp *http.Response, body string, contentLength int) protocols.I
 	return event
 }
 
-func (e *XrayEngine) addFramework(frames common.Frameworks, tmpl *templates.Template) {
+func (e *XrayEngine) newFramework(tmpl *templates.Template) *common.Framework {
 	name := tmpl.Info.Name
 	if name == "" {
 		name = tmpl.Id
@@ -219,7 +218,7 @@ func (e *XrayEngine) addFramework(frames common.Frameworks, tmpl *templates.Temp
 			frame.Attributes.Product = product
 		}
 	}
-	frames.Add(frame)
+	return frame
 }
 
 // ServiceMatch is not supported by the xray engine.
@@ -302,13 +301,9 @@ func (e *XrayEngine) HTTPActiveMatch(baseURL string, level int, transport http.R
 
 		result, err := tmpl.Execute(baseURL, nil)
 		if err == nil && result != nil && result.Matched {
-			e.addFramework(allFrameworks, tmpl)
+			frame := e.newFramework(tmpl)
+			allFrameworks.Add(frame)
 			if callback != nil {
-				name := tmpl.Info.Name
-				if name == "" {
-					name = tmpl.Id
-				}
-				frame := common.NewFramework(name, FrameFromXray)
 				callback(frame, nil)
 			}
 		}

--- a/xray/xray.go
+++ b/xray/xray.go
@@ -37,11 +37,15 @@ func init() {
 type XrayEngine struct {
 	templates       []*templates.Template
 	executerOptions *protocols.ExecuterOptions
+
+	// CaseInsensitive 控制匹配时是否忽略大小写（默认 true）。
+	CaseInsensitive bool
 }
 
 // NewXrayEngine creates a new xray fingerprint engine from gzipped JSON data.
 func NewXrayEngine(webData []byte) (*XrayEngine, error) {
 	engine := &XrayEngine{
+		CaseInsensitive: true,
 		executerOptions: &protocols.ExecuterOptions{
 			Options: &protocols.Options{Timeout: 10},
 		},
@@ -84,7 +88,7 @@ func (e *XrayEngine) loadTemplates(data []map[string]interface{}) (int, []error)
 			errs = append(errs, fmt.Errorf("unmarshal: %w", err))
 			continue
 		}
-		if err := tmpl.Compile(e.executerOptions); err != nil {
+		if err := e.compileTemplate(tmpl); err != nil {
 			for _, req := range tmpl.GetRequests() {
 				if compileErr := (&req.Operators).Compile(); compileErr != nil {
 					continue
@@ -98,6 +102,19 @@ func (e *XrayEngine) loadTemplates(data []map[string]interface{}) (int, []error)
 		}
 	}
 	return loaded, errs
+}
+
+func (e *XrayEngine) compileTemplate(tmpl *templates.Template) error {
+	if e.CaseInsensitive {
+		for _, req := range tmpl.GetRequests() {
+			for _, matcher := range req.Matchers {
+				if matcher.Type == "word" {
+					matcher.CaseInsensitive = true
+				}
+			}
+		}
+	}
+	return tmpl.Compile(e.executerOptions)
 }
 
 // ---------------------------------------------------------------------------
@@ -119,8 +136,11 @@ func (e *XrayEngine) WebMatch(content []byte) common.Frameworks {
 		return make(common.Frameworks)
 	}
 
-	body := string(bytes.ToLower(httputils.ReadBody(resp)))
-	event := buildEvent(resp, body, len(content))
+	bodyStr := string(httputils.ReadBody(resp))
+	if e.CaseInsensitive {
+		bodyStr = strings.ToLower(bodyStr)
+	}
+	event := e.buildEvent(resp, bodyStr, len(content))
 	frames := make(common.Frameworks)
 
 	for _, tmpl := range e.templates {
@@ -183,7 +203,7 @@ func matchRequest(req *nhttp.Request, event protocols.InternalEvent) bool {
 	return anyMatched
 }
 
-func buildEvent(resp *http.Response, body string, contentLength int) protocols.InternalEvent {
+func (e *XrayEngine) buildEvent(resp *http.Response, body string, contentLength int) protocols.InternalEvent {
 	event := make(protocols.InternalEvent)
 	event["body"] = body
 	event["status_code"] = resp.StatusCode
@@ -193,10 +213,13 @@ func buildEvent(resp *http.Response, body string, contentLength int) protocols.I
 	for k, vals := range resp.Header {
 		joined := strings.Join(vals, " ")
 		norm := strings.ToLower(strings.Replace(strings.TrimSpace(k), "-", "_", -1))
-		event[norm] = strings.ToLower(joined)
+		if e.CaseInsensitive {
+			joined = strings.ToLower(joined)
+		}
+		event[norm] = joined
 		hdrBuilder.WriteString(norm)
 		hdrBuilder.WriteString(": ")
-		hdrBuilder.WriteString(strings.ToLower(joined))
+		hdrBuilder.WriteString(joined)
 		hdrBuilder.WriteString("\n")
 	}
 	event["all_headers"] = hdrBuilder.String()


### PR DESCRIPTION
## Summary

从 #14 中提取的有效修复（#14 因历史重写导致 diff 包含全部 100+ commits 的噪音，已关闭）。

### 问题 1: HTTPActiveMatch callback 返回错误的 framework

**fingerprinthub**: `callback(allFrameworks.One(), nil)` — `One()` 遍历 map 返回第一个元素，在多模板匹配时返回的不一定是刚匹配到的 framework。

**xray**: callback 中手动 `NewFramework()` 但未设置 vendor/product metadata，而 `addFramework()` 中有。导致回调拿到的 framework 缺少属性。

**修复**: `addFramework` 返回刚创建的 `*Framework`，callback 直接使用。

### 问题 2: 模板编译创建多余的中间 ExecuterOptions

```go
opts := &protocols.ExecuterOptions{Options: engine.executerOptions.Options}
tmpl.Compile(opts)
```

只复制了 `Options` 字段，`Variables` 等其他字段丢失。改为直接传 `engine.executerOptions`。

### 问题 3: 新增回归测试

`TestWebMatch_DSLCaseSensitivity` 确保 DSL matcher（如 `contains(body, "<title>Nacos")`）能正确匹配混合大小写的 body，防止 body ToLower 问题回归。

## PR #14 分析

PR #14 声称的核心问题"WebMatch 把 body ToLower 导致 DSL/regex matcher 失效"**在当前 master 上已修复**。

PR #14 中**错误的改动**：删除 `CaseInsensitive = true` hack — neutron 的 `MatchWords` 只在 `CaseInsensitive=true` 时才做 ToLower（`matcher.go:184`），删掉会导致所有 word matcher 失效。

## Test plan

- [x] `TestWebMatch_DSLCaseSensitivity` 通过
- [x] `TestFingerPrintHubEngine_Basic` 通过
- [x] `go build ./...` 通过
- [x] `go vet ./fingerprinthub/ ./xray/` 通过