### PR TITLE
fix: handle non-string vuln payload values

### DIFF
--- a/common/vuln.go
+++ b/common/vuln.go
@@ -3,6 +3,7 @@ package common
 import (
 	"fmt"
 	"github.com/chainreactors/utils/iutils"
+	"sort"
 	"strings"
 )
 
@@ -55,7 +56,21 @@ func (v *Vuln) HasTag(tag string) bool {
 }
 
 func (v *Vuln) GetPayload() string {
-	return iutils.MapToString(v.Payload)
+	if v.Payload == nil || len(v.Payload) == 0 {
+		return ""
+	}
+
+	keys := make([]string, 0, len(v.Payload))
+	for k := range v.Payload {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var s strings.Builder
+	for _, k := range keys {
+		s.WriteString(fmt.Sprintf(" %s:%v ", k, v.Payload[k]))
+	}
+	return s.String()
 }
 
 func (v *Vuln) GetDetail() string {

--- a/common/vuln_test.go
+++ b/common/vuln_test.go
@@ -1,0 +1,18 @@
+package common
+
+import "testing"
+
+func TestVulnGetPayloadFormatsNonStringValues(t *testing.T) {
+	vuln := &Vuln{
+		Payload: map[string]interface{}{
+			"key":   "value",
+			"count": 1,
+		},
+	}
+
+	got := vuln.GetPayload()
+	want := " count:1  key:value "
+	if got != want {
+		t.Fatalf("GetPayload() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## 背景

在 aiscan 的 verify/sniper 流程中使用 neutron 模板验证漏洞时，模板已经匹配成功，但程序在格式化漏洞结果时崩溃：

```text
panic: interface conversion: interface {} is int, not string
```

也就是说，漏洞检测本身可能已经拿到了有效命中结果，但调用方还没来得及输出/消费这个结果，进程就在 `common.Vuln.String()` -> `Vuln.GetPayload()` 阶段 panic 了。

## 根因

`Vuln.Payload` 的定义是：

```go
map[string]interface{}
```

但是旧的 `GetPayload()` 直接调用了 `iutils.MapToString()`。这个工具函数内部假设所有 value 都是 string，并做了硬类型断言：

```go
v.(string)
```

实际模板运行时，payload 里可能出现非 string 类型，例如 int。此时漏洞模板已经命中，但只要进入结果格式化阶段，就会因为类型断言失败而 panic。

## 修复内容

本 PR 将 `Vuln.GetPayload()` 改为在本地格式化 payload，不再使用只支持 string value 的 helper：

- 使用 `%v` 格式化 `interface{}` value，支持 int 等非 string 类型
- 保持 nil/空 payload 返回空字符串的原行为
- 对 payload key 排序，保证输出稳定，方便测试和日志对比
- 不改动模板匹配逻辑、请求生成逻辑或漏洞验证语义

## 影响范围

这个修复只影响漏洞结果的字符串格式化。

对下游调用方，例如 aiscan，当 neutron 模板命中后 payload 中包含 int 等非 string value 时，不会再因为输出结果而崩溃，可以继续完成 verify/sniper 后续流程。

## 测试

新增回归测试，覆盖 payload 同时包含 string 和 int 的情况。

```text
go test ./common
```
